### PR TITLE
feat: add wattpilot shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,37 @@
 
 `wattpilot` is a Python 3 (>= 3.9) module to interact with Fronius Wattpilot wallboxes which do not support (at the time of writting) a documented API. This functionality of this module utilized a undocumented websockets API, which is also utilized by the official Wattpilot.Solar mobile app.
 
+## Wattpilot Shell
+
+The shell provides an easy way to explore the available properties and get or set their values.
+
+```bash
+# Install the wattpilot module, if not yet done so:
+pip install .
+```
+
+Run the interactive shell
+
+```bash
+# Usage:
+python3 shell.py <wattpilot_ip> <password>
+> help
+Wattpilot Shell Commands:
+  dump: Dump all property values
+  exit: Exit the shell
+  get <name>: Get a property value
+  info: Print most important infos
+  list: List all known property keys
+  set <name> <value>: Set a property value
+```
+
+It's also possible to pass a single command to the shell to integrate it into scripts:
+
+```bash
+# Usage:
+python3 shell.py <wattpilot_ip> <password> "<command> <args...>"
+
+# Examples:
+python3 shell.py <wattpilot_ip> <password> "get amp"
+python3 shell.py <wattpilot_ip> <password> "set amp 6"
+```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Wattpilot Shell Commands:
   info: Print most important infos
   list: List all known property keys
   set <name> <value>: Set a property value
+  watch message <type>: Watch message of given message type
+  watch property <name>: Watch value changes of given property name
+  unwatch message <type>: Unwatch messages of given message type
+  unwatch property <name>: Unwatch value changes of given property name
 ```
 
 It's also possible to pass a single command to the shell to integrate it into scripts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "pyyaml>=5.4.1",
     "setuptools>=42",
-    "wheel"
+    "wheel",
+    "pyreadline"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
+    "pyyaml>=5.4.1",
     "setuptools>=42",
     "wheel"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 websocket-client>=1.2.3
-
+PyYAML>=5.4.1
+pyreadline

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_dir={'': 'src'}, 
     packages=find_packages(where='src'),
     python_requires='>=3.9, <4',
-    install_requires=['websocket-client'],
+    install_requires=['websocket-client','PyYAML','pyreadline'],
     platforms="any",
     license="MIT License",
     project_urls={

--- a/shell.py
+++ b/shell.py
@@ -1,0 +1,127 @@
+import argparse
+import json
+import logging
+import readline
+import wattpilot
+
+from time import sleep
+from types import SimpleNamespace
+
+_LOGGER = logging.getLogger(__name__)
+
+def process_command(wp, cmdline):
+    """Process a Wattpilot shell command"""
+    exit = False
+    cmd_args = cmd_parser.parse_args(args=cmdline.strip().split(' '))
+    cmd = cmd_args.cmd.strip()
+    args = cmd_args.args
+    if (cmd == ''):
+        # Don't do anything
+        exit = False
+    elif (cmd == 'dump'):
+        for key, value in sorted(wp.allProps.items(), key=lambda x: x[0]): 
+            print("{}: {}".format(key, value))
+    elif cmd == "exit":
+        exit = True
+    elif (cmd == 'get'):
+        if len(args) != 1:
+            print(f"Wrong number of arguments: get <property>")
+        elif not args[0] in wp.allProps:
+            print(f"Unknown property: {args[0]}")
+        else:
+            print(wp.allProps[args[0]])
+    elif (cmd == 'help'):
+        print("Wattpilot Shell Commands:")
+        print("  dump: Dump all property values")
+        print("  exit: Exit the shell")
+        print("  get <name>: Get a property value")
+        print("  info: Print most important infos")
+        print("  list: List all known property keys")
+        print("  set <name> <value>: Set a property value")
+    elif (cmd == 'info'):
+        print(wp)
+    elif (cmd == 'list'):
+        for key in sorted(wp.allProps.keys()): 
+            print(f"{key} ", end="")
+        print()
+    elif (cmd == 'set'):
+        if len(args) != 2:
+            print(f"Wrong number of arguments: set <property> <value>")
+        elif not args[0] in wp.allProps:
+            print(f"Unknown property: {args[0]}")
+        else:
+            if str(args[1]).isnumeric():
+                v=int(args[1])
+            elif str(args[1]).isdecimal():
+                v=float(args[1])
+            else:
+                v=str(args[1])
+            wp.send_update(args[0],v)
+    else:
+        print(f"Unknown command: {cmd}")
+    return exit
+
+def complete(text,state):
+    """Simple readline completer"""
+    volcab = ['dump','exit','get','help','info','list','set']
+    results = [x for x in volcab if x.startswith(text)] + [None]
+    return results[state]
+
+def wait_timeout(fn, timeout):
+    """Generic timeout waiter"""
+    t = 0
+    within_timeout = True
+    while not fn() and t<timeout:
+        sleep(1)
+        t += 1
+    if t>=timeout:
+        within_timeout = False
+    return within_timeout
+
+
+# Timeouts:
+connect_timeout = 10
+initialized_timeout = 10
+
+# Set debug level:
+logging.basicConfig(level='WARNING')
+
+# Setup readline
+readline.parse_and_bind("tab: complete")
+readline.set_completer(complete) 
+
+# Commandline argument parser:
+parser = argparse.ArgumentParser()
+parser.add_argument("ip", help = "IP of Wattpilot Device")
+parser.add_argument("password", help = "Password of Wattpilot")
+parser.add_argument("cmdline", help = "Optional shell command", nargs="?")
+args = parser.parse_args()
+
+# Wattpilot shell command parser:
+cmd_parser = argparse.ArgumentParser()
+cmd_parser.add_argument("cmd", help = "Command")
+cmd_parser.add_argument("args", help = "Arguments", nargs='*')
+
+# Connect to Wattpilot:
+wp = wattpilot.Wattpilot(args.ip,args.password)
+wp.connect()
+
+# Wait for connection and initializon:
+wait_timeout(lambda: wp.connected, connect_timeout) or exit("ERROR: Timeout while connecting to Wattpilot!")
+wait_timeout(lambda: wp.allPropsInitialized, initialized_timeout) or exit("ERROR: Timeout while waiting for property initialization!")
+
+# Process commands:
+if args.cmdline:
+    # Process commands passed on the commandline
+    process_command(wp,args.cmdline)
+else:
+    # Start interactive shell
+    process_command(wp,"info")
+    exit=False
+    while not exit:
+        try:
+            command = input('> ')
+        except EOFError as e:
+            command = "exit"
+            print()
+        exit = process_command(wp,command)

--- a/shell.py
+++ b/shell.py
@@ -34,6 +34,10 @@ def printPropInfo(wpi, propName, value):
     if 'example' in propInfo:
         print(f"  Example: {propInfo['example']}")
 
+def watch_properties(name,value):
+    if name in watching_properties:
+        print(f"INFO: Property {name} changed to {value}")
+
 def process_command(wp, wpi, cmdline):
     """Process a Wattpilot shell command"""
     exit = False
@@ -63,6 +67,8 @@ def process_command(wp, wpi, cmdline):
         print("  info: Print most important infos")
         print("  list: List all known property keys")
         print("  set <name> <value>: Set a property value")
+        print("  watch <name>: Watch property value changes")
+        print("  unwatch <name>: Unwatch property value changes")
     elif (cmd == 'info'):
         print(wp)
     elif (cmd == 'list'):
@@ -83,6 +89,25 @@ def process_command(wp, wpi, cmdline):
             else:
                 v=str(args[1])
             wp.send_update(args[0],v)
+    elif (cmd == 'watch'):
+        if len(args) != 1:
+            print(f"Wrong number of arguments: watch <property>")
+        elif not args[0] in wp.allProps:
+            print(f"Unknown property: {args[0]}")
+        else:
+            if len(watching_properties) == 0:
+                wp.register_property_callback(watch_properties)
+            if args[0] not in watching_properties:
+                watching_properties.append(args[0])
+    elif (cmd == 'unwatch'):
+        if len(args) != 1:
+            print(f"Wrong number of arguments: watch <property>")
+        elif not args[0] in watching_properties:
+            print(f"Property {args[0]} is not watched")
+        else:
+            watching_properties.remove(args[0])
+            if len(watching_properties) == 0:
+                wp.unregister_property_callback()
     else:
         print(f"Unknown command: {cmd}")
     return exit
@@ -108,6 +133,9 @@ def wait_timeout(fn, timeout):
 # Timeouts:
 connect_timeout = 10
 initialized_timeout = 10
+
+# Globals:
+watching_properties = []
 
 # Set debug level:
 logging.basicConfig(level='WARNING')

--- a/src/wattpilot/__init__.py
+++ b/src/wattpilot/__init__.py
@@ -284,6 +284,20 @@ class Wattpilot(object):
         
         _LOGGER.info("Wattpilot connected")
 
+    def register_message_callback(self,callback_fn):
+        """signature of callback_fn: (wsapp,msg)"""
+        self._message_callback = callback_fn
+
+    def unregister_message_callback(self):
+        self._message_callback = None
+
+    def register_property_callback(self,callback_fn):
+        """signature of callback_fn: (name,value)"""
+        self._property_callback = callback_fn
+
+    def unregister_property_callback(self):
+        self._property_callback = None
+
     def set_power(self,power):
         self.send_update("amp",power)
 
@@ -371,6 +385,8 @@ class Wattpilot(object):
                 self._updateAvailable = False
             else:
                 self._updateAvailable = True
+        if self._property_callback != None:
+            self._property_callback(name,value)
 
     def __on_hello(self,message):
         _LOGGER.info("Connected to WattPilot Serial %s",message.serial)
@@ -483,6 +499,8 @@ class Wattpilot(object):
             self.__on_clearInverters(msg)
         if (msg.type == 'updateInverter'): # Contains information of connected Photovoltaik inverter / powermeter
             self.__on_updateInverter(msg)
+        if self._message_callback != None:
+            self._message_callback(wsapp,msg)
 
 
     def __init__(self, ip ,password,serial=None,cloud=False):
@@ -531,6 +549,8 @@ class Wattpilot(object):
         self._carConnected=None
         self._cae=None
         self._cak=None
+        self._message_callback=None
+        self._property_callback=None
 
         self._wst=threading.Thread()
 

--- a/src/wattpilot/__init__.py
+++ b/src/wattpilot/__init__.py
@@ -61,6 +61,16 @@ class Wattpilot(object):
 
 
     @property
+    def allProps(self):
+        """Returns a dictionary with all properties"""
+        return self._allProps
+
+    @property
+    def allPropsInitialized(self):
+        """Returns true, if all properties have been initialized"""
+        return self._allPropsInitialized
+
+    @property
     def cableType(self):
         """Returns the Cable Type (Ampere) of the connected cable"""
         return self._cableType
@@ -259,6 +269,7 @@ class Wattpilot(object):
             ret = ret + "Car Connected: " + str(self.carConnected) + "\n"
             ret = ret + "Charge Status " + str(self.AllowCharging) + "\n"
             ret = ret + "Mode: " + str(self.mode) + "\n"
+            ret = ret + "Power: " + str(self.amp) + "\n"
             ret = ret +  "Charge: " + "%.2f" % self.power + "kW" + " ---- " + str(self.voltage1) + "V/" + str(self.voltage2) + "V/" + str(self.voltage3) + "V" + " -- "
             ret = ret + "%.2f" % self.amps1 + "A/" + "%.2f" % self.amps2 + "A/" + "%.2f" % self.amps3 + "A" + " -- "
             ret = ret + "%.2f" % self.power1 + "kW/" + "%.2f" % self.power2 + "kW/" + "%.2f" % self.power3 + "kW" + "\n"
@@ -297,6 +308,7 @@ class Wattpilot(object):
 
     def __update_property(self,name,value):
 
+        self._allProps[name] = value
         if name=="acs":
             self._AccessState = Wattpilot.acsValues[value]
 
@@ -420,6 +432,7 @@ class Wattpilot(object):
             _LOGGER.error("Authentification failed: %s" , message.message)
 
     def __on_DeltaStatus(self,message):
+        self._allPropsInitialized=True # Assume all properties have been initialized when first delta status is received
         props = message.status.__dict__
         for key in props:
             self.__update_property(key,props[key])
@@ -494,6 +507,8 @@ class Wattpilot(object):
             self._url = "ws://"+ip+"/ws"
         self.serial = None
         self._connected = False
+        self._allProps={}
+        self._allPropsInitialized=False
         self._voltage1=None
         self._voltage2=None
         self._voltage3=None

--- a/wattpilot.yaml
+++ b/wattpilot.yaml
@@ -1,0 +1,1012 @@
+# Message property values:
+# - name: Unique message name that is used by the Wattpilot API
+# - title: A short descriptive title of the message
+# - description: A longer description of the message
+messages:
+  hello:
+    title: Hello Message
+    description: Received upon connection before authentication
+  authRequired:
+    title: Auth Required
+    description: Received after hello to ask for authentication
+  response:
+    title: Update Response Message
+    description: Received after sending an update and contains the result of the update
+  authSuccess:
+    title: Auth Success
+    description: Received after sending a correct authentication message
+  authError:
+    title: Auth Error
+    description: Received after sending an incorrect authentication message (e.g. wrong password)
+  fullStatus:
+    title: Full Status
+    description: Set of messages received after successful connection. These messages contain all properties of Wattpilot.
+  deltaStatus:
+    title: Delta Status
+    description: Whenever a property changes a Delta Status is sent
+  clearInverters:
+    title: Clear Inverters
+    description: Unknown
+  updateInverter:
+    title: Update Inverter
+    description: Contains information of connected PV inverter / power meter
+
+# Available property values:
+# - name: Unique name that is used by the Wattpilot API
+# - type: Type of the property: array|boolean|integer|float|object|unknown
+# - example: Typical example values to help at deriving the meaning of fields.
+# - itemType: Type of an array item in case the type is 'array'
+# - title: A short descriptive title of the property
+# - description: A longer description of the property
+# - alias: A unique alias that can be used as a better descriptive name for a self-descriptive API
+# - min: Minimum value in case the type is 'integer' or 'float'
+# - max: Maximum value in case the type is 'integer' or 'float'
+properties:
+  abm:
+    type: string
+    example: <SOME_MAC>
+  acs:
+    type: integer
+    example: 0
+    alias: accessState
+  acu:
+    type: integer
+    example: 6
+  acui:
+    type: integer
+    example: 6
+  adi:
+    type: boolean
+    example: True
+  al1:
+    type: integer
+    example: 6
+  al2:
+    type: integer
+    example: 10
+  al3:
+    type: integer
+    example: 12
+  al4:
+    type: integer
+    example: 14
+  al5:
+    type: integer
+    example: 16
+  alw:
+    type: boolean
+    example: True
+    alias: allowCharging
+  ama:
+    type: integer
+    example: 16
+  amp:
+    type: integer
+    example: 6
+    alias: chargingCurrent
+    title: Charging Current
+    description: The current to be used for charging
+    min: 6
+    max: 16
+  amt:
+    type: integer
+    example: 32
+  apd:
+    type: object
+    example: project_name='wattpilot_hw4+', version='36.3', secure_version=0, timestamp='Jan 31 2022 22:51:39', idf_ver='v5.0-dev-1103-ga9ef558d', sha256='<some_sha256>'
+  arv:
+    type: string
+    example: 1.2.1
+  asc:
+    type: boolean
+    example: True
+  aup:
+    type: integer
+    example: 6
+  awc:
+    type: integer
+    example: 0
+  awcp:
+    alias: awattarCurrentPrice
+    type: object
+    example: start=1646560800, end=1646564400, marketprice=34.625
+    title: Awattar Current Price?
+  awp:
+    type: integer
+    example: 3
+  awpl:
+    title: Awattar Price List
+    description: Dynamic energy prices
+    type: array
+    itemType: object
+    example: start=1646560800, end=1646564400, marketprice=34.625
+  bac:
+    type: boolean
+    example: True
+  bam:
+    type: boolean
+    example: True
+  cae:
+    type: boolean
+    example: False
+  cak:
+    type: string
+    example: 
+  car:
+    type: integer
+    example: 1
+    alias: carConnected
+  cards:
+    title: RFID Card List
+    type: array
+    itemType: object
+    example: name='User 1', energy=0, cardId=True
+    description: Registered RFID cards for different users
+  cbl:
+    type: integer
+    example: 20
+    alias: cableType
+  cbm:
+    type: unknown
+    example: None
+  cca:
+    type: boolean
+    example: True
+  cch:
+    type: string
+    example: #00FFF
+  cci:
+    type: object
+    example: id='<some_numeric_id>', paired=True, deviceFamily='DataManager', label='<some_name>', model='PILOT', commonName='pilot-0.5e-1670626369628648631_1599713577', ip='<some_ip>', connected=True, reachableMdns=True, reachableUdp=False, reachableHttp=True, status=0, message='ok'
+  cco:
+    type: integer
+    example: 24
+  ccu:
+    type: unknown
+    example: None
+  ccw:
+    type: object
+    example: ssid='<SOME_SSID>', encryptionType=3, pairwiseCipher=4, groupCipher=4, b=True, g=True, n=True, lr=False, wps=False, ftmResponder=False, ftmInitiator=False, channel=6, bssid='<SOME_BSSID>', ip='<some_ip4>', netmask='255.255.255.0', gw='<some_ip4>', ipv6=['<some_ip6>'], dns0='<some_ip4>', dns1='0.0.0.0', dns2='0.0.0.0'
+  cdi:
+    type: object
+    example: type=1, value=<some_large_integer>
+  cdv:
+    type: unknown
+    example: None
+  cfi:
+    type: string
+    example: #00FF00
+  chr:
+    type: boolean
+    example: True
+  cid:
+    type: string
+    example: #0000FF
+  clp:
+    type: array
+    example: [6, 10, 12, 14, 16]
+    itemType: integer
+    title: Charging Current Options
+    description: List of possible charging current options for property 'amp'
+  cpe:
+    type: boolean
+    example: True
+  cpr:
+    type: boolean
+    example: True
+  csca:
+    type: integer
+    example: 2
+  ct:
+    type: string
+    example: vwID3_4
+  cus:
+    type: integer
+    example: 1
+  cwc:
+    type: string
+    example: #FFFF00
+  cwe:
+    type: boolean
+    example: True
+  cws:
+    type: boolean
+    example: True
+  cwsc:
+    type: boolean
+    example: True
+  cwsca:
+    type: integer
+    example: 46954034
+  data:
+    type: string
+    example: {"i":120,"url":"https://data.wattpilot.io/data?e=<some_token>"}
+  dbm:
+    type: string
+    example: <SOME_MAC_ADDRESS>
+  dccu:
+    type: boolean
+    example: False
+  dco:
+    type: boolean
+    example: True
+  dll:
+    type: string
+    example: https://data.wattpilot.io/export?e=<some_token>
+  dns:
+    type: object
+    example: dns='0.0.0.0'
+  dwo:
+    type: unknown
+    example: None
+  ecf:
+    type: object
+    example: source=1, source_freq_mhz=320, div=2, freq_mhz=160
+  eci:
+    type: object
+    example: model=1, features=50, cores=2, revision=3
+  efh:
+    type: integer
+    example: 125920
+  efh32:
+    type: integer
+    example: 125920
+  efh8:
+    type: integer
+    example: 86848
+  efi:
+    type: unknown
+    example: None
+  ehs:
+    type: integer
+    example: 282800
+  emfh:
+    type: integer
+    example: 78104
+  emhb:
+    type: integer
+    example: 67572
+  ens:
+    type: string
+    example: 
+  err:
+    type: integer
+    example: 0
+    alias: errorState
+  esk:
+    type: boolean
+    example: True
+  esr:
+    type: array
+    example: [12, 12]
+    itemType: integer
+  eto:
+    type: integer
+    example: 1076098
+    alias: energyCounterTotal
+  etop:
+    type: integer
+    example: 1076098
+  facwak:
+    type: boolean
+    example: True
+  fam:
+    type: integer
+    example: 20
+  fap:
+    type: boolean
+    example: False
+  fbuf_age:
+    type: integer
+    example: 93639347
+  fbuf_akkuMode:
+    type: integer
+    example: 1
+  fbuf_akkuSOC:
+    type: float
+    example: 72.5
+  fbuf_ohmpilotState:
+    type: unknown
+    example: None
+  fbuf_ohmpilotTemperature:
+    type: unknown
+    example: None
+  fbuf_pAcTotal:
+    type: unknown
+    example: None
+  fbuf_pAkku:
+    type: float
+    example: -3985.899
+  fbuf_pGrid:
+    type: integer
+    example: 11
+  fbuf_pPv:
+    type: float
+    example: 4701.407
+  fcc:
+    type: boolean
+    example: True
+  fck:
+    type: boolean
+    example: True
+  fem:
+    type: integer
+    example: 2
+  ferm:
+    type: integer
+    example: 1
+  ffb:
+    type: integer
+    example: 0
+  ffba:
+    type: unknown
+    example: None
+  ffna:
+    type: string
+    example: Wattpilot_<some_serialnr>
+  fhi:
+    type: boolean
+    example: True
+  fhz:
+    type: float
+    example: 49.815
+    alias: frequency
+  fi23:
+    type: boolean
+    example: True
+  fio23:
+    type: boolean
+    example: True
+  fit:
+    type: integer
+    example: 1
+  fml:
+    type: string
+    example: grid
+  fmmp:
+    type: integer
+    example: 0
+  fmt:
+    type: integer
+    example: 900000
+  fna:
+    type: string
+    example: <some_name>
+  fntp:
+    type: unknown
+    example: None
+  fot:
+    type: integer
+    example: 20
+  frc:
+    type: integer
+    example: 0
+  frci:
+    type: boolean
+    example: True
+  fre:
+    type: boolean
+    example: False
+  frm:
+    type: integer
+    example: 1
+  fsp:
+    type: boolean
+    example: False
+  fsptws:
+    type: integer
+    example: 28771782
+  fst:
+    type: integer
+    example: 1400
+  fte:
+    type: integer
+    example: 50000
+  ftlf:
+    type: boolean
+    example: False
+  ftls:
+    type: unknown
+    example: None
+  ftt:
+    type: integer
+    example: 25200
+  ful:
+    type: boolean
+    example: False
+  fup:
+    type: boolean
+    example: True
+  fwan:
+    type: string
+    example: Wattpilot_<some_serialnr>
+  fwc:
+    type: integer
+    example: 10
+  fwv:
+    type: string
+    example: 36.3
+    alias: firmwareVersion
+  fzf:
+    type: boolean
+    example: False
+  gme:
+    type: boolean
+    example: False
+  gmk:
+    type: string
+    example: 
+  host:
+    type: string
+    example: Wattpilot_<some_serialnr>
+  hsa:
+    type: boolean
+    example: True
+  hsta:
+    type: string
+    example: Wattpilot_<some_serialnr>
+  hsts:
+    type: string
+    example: Wattpilot_<some_serialnr>
+  hws:
+    type: boolean
+    example: True
+  ido:
+    type: unknown
+    example: None
+  imd:
+    type: boolean
+    example: False
+  imi:
+    type: integer
+    example: 0
+  immr:
+    type: integer
+    example: 20
+  imp:
+    type: string
+    example: _tcp
+  ims:
+    type: string
+    example: _Fronius-SE-Inverter
+  imse:
+    type: boolean
+    example: True
+  irs:
+    type: boolean
+    example: False
+  isml:
+    type: boolean
+    example: False
+  iuse:
+    type: boolean
+    example: True
+  las:
+    type: integer
+    example: 0
+  lbh:
+    type: unknown
+    example: None
+  lbp:
+    type: unknown
+    example: None
+  lbr:
+    type: integer
+    example: 255
+  lbs:
+    type: integer
+    example: 806
+  lccfc:
+    type: integer
+    example: 7157569
+  lccfi:
+    type: integer
+    example: 5369660
+  lcctc:
+    type: integer
+    example: 5369660
+  lch:
+    type: integer
+    example: 5369660
+  lck:
+    type: integer
+    example: 0
+  led:
+    type: object
+    example: id=16, name='Ready', norwayOverlay=True, modeOverlay=True, subtype='renderCmds', ranges=[namespace(from=0, to=5, colors=['#0000FF']), namespace(from=6, to=31, colors=['#000000'])]
+  ledo:
+    type: unknown
+    example: None
+  lfspt:
+    type: unknown
+    example: None
+  llr:
+    type: integer
+    example: 2
+  lmo:
+    type: integer
+    example: 3
+    alias: mode
+  lmsc:
+    type: integer
+    example: 28822622
+  loa:
+    type: unknown
+    example: None
+  loc:
+    type: string
+    example: 2022-03-06T11:59:38.182.123 +01:00
+  loe:
+    type: boolean
+    example: False
+  lof:
+    type: integer
+    example: 0
+  log:
+    type: string
+    example: 
+  loi:
+    type: boolean
+    example: False
+  lom:
+    type: unknown
+    example: None
+  lop:
+    type: integer
+    example: 50
+  los:
+    type: unknown
+    example: None
+  lot:
+    type: integer
+    example: 32
+  loty:
+    type: integer
+    example: 0
+  lps:
+    type: integer
+    example: 63
+  lpsc:
+    type: integer
+    example: 28771782
+  lrc:
+    type: unknown
+    example: None
+  lri:
+    type: unknown
+    example: None
+  lrr:
+    type: unknown
+    example: None
+  lse:
+    type: boolean
+    example: False
+  lssfc:
+    type: unknown
+    example: None
+  lsstc:
+    type: integer
+    example: 7970
+  maca:
+    type: string
+    example: <some_mac>
+  macs:
+    type: string
+    example: <some_mac>
+  map:
+    type: array
+    example: [1, 2, 3]
+    itemType: integer
+  mca:
+    type: integer
+    example: 6
+  mci:
+    type: integer
+    example: 0
+  mcpd:
+    type: integer
+    example: 0
+  mcpea:
+    type: unknown
+    example: None
+  mod:
+    type: integer
+    example: 1
+  modelStatus:
+    type: integer
+    example: 15
+  mptwt:
+    type: integer
+    example: 600000
+  mpwst:
+    type: integer
+    example: 120000
+  msca:
+    type: integer
+    example: 0
+  mscs:
+    type: integer
+    example: 188
+  msi:
+    type: integer
+    example: 15
+  mws:
+    type: boolean
+    example: True
+  nif:
+    type: string
+    example: st
+  nmo:
+    type: boolean
+    example: False
+  nrg:
+    type: array
+    example: [235, 234, 234, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    itemType: integer # or float?
+    alias: energy
+  nvs:
+    type: object
+    example: used_entries=115, free_entries=7949, total_entries=8064, namespace_count=2, nvs_handle_user=47
+  obm:
+    type: unknown
+    example: None
+  oca:
+    type: unknown
+    example: None
+  occa:
+    type: integer
+    example: 2
+  ocl:
+    type: unknown
+    example: None
+  ocm:
+    type: string
+    example: 
+  ocp:
+    type: integer
+    example: 0
+  ocppc:
+    type: boolean
+    example: False
+  ocppca:
+    type: unknown
+    example: None
+  ocppe:
+    type: boolean
+    example: False
+  ocpph:
+    type: integer
+    example: 3600
+  ocppi:
+    type: integer
+    example: 0
+  ocppl:
+    type: integer
+    example: 1
+  ocpps:
+    type: boolean
+    example: False
+  ocppu:
+    type: string
+    example: ws://echo.websocket.org/
+  ocs:
+    type: integer
+    example: 0
+  ocu:
+    type: array
+    example: ['__default']
+    itemType: string
+  ocuca:
+    type: boolean
+    example: True
+  oem:
+    type: string
+    example: fronius
+  onv:
+    type: string
+    example: 36.3
+  otap:
+    type: object
+    example: type=0, subtype=16, address=1441792, size=4194304, label='app_0', encrypted=True
+  part:
+    type: array
+    itemType: object
+    example: type=1, subtype=2, address=65536, size=262144, label='nvs', encrypted=False
+  pha:
+    alias: phases
+    type: array
+    example: [False, False, False, True, True, True]
+    itemType: boolean
+  pnp:
+    type: integer
+    example: 0
+  po:
+    type: integer
+    example: -300
+  psh:
+    type: integer
+    example: 500
+  psm:
+    type: integer
+    example: 0
+  psmd:
+    type: integer
+    example: 10000
+  pto:
+    type: integer
+    example: 61440
+  pvopt_averagePAkku:
+    type: float
+    example: -5213.455
+  pvopt_averagePGrid:
+    type: float
+    example: 1.923335
+  pvopt_averagePOhmpilot:
+    type: integer
+    example: 0
+  pvopt_averagePPv:
+    type: float
+    example: 6008.117
+  pvopt_deltaA:
+    type: integer
+    example: 0
+  pvopt_deltaP:
+    type: float
+    example: -1256.149
+  pvopt_specialCase:
+    type: integer
+    example: 0
+  pwm:
+    type: integer
+    example: 0
+  qsc:
+    type: integer
+    example: 0
+  qsw:
+    type: integer
+    example: 5
+  rbc:
+    type: integer
+    example: 32
+  rbt:
+    type: integer
+    example: 93641458
+  rcd:
+    type: unknown
+    example: None
+  rcsl:
+    type: boolean
+    example: False
+  rfb:
+    type: integer
+    example: 1699
+  rfide:
+    type: boolean
+    example: True
+  rial:
+    type: boolean
+    example: False
+  riml:
+    type: boolean
+    example: False
+  risl:
+    type: boolean
+    example: False
+  riul:
+    type: boolean
+    example: False
+  rmdns:
+    type: boolean
+    example: False
+  rr:
+    type: integer
+    example: 4
+  rrca:
+    type: integer
+    example: 2
+  rssi:
+    type: integer
+    example: -66
+  sau:
+    type: boolean
+    example: False
+  sbe:
+    type: boolean
+    example: True
+  scaa:
+    type: integer
+    example: 6429
+  scan:
+    type: array
+    itemType: object
+    example: ssid='<SOME_SSID>', encryptionType=3, rssi=-66, channel=6, bssid='<SOME_BSSID>', f=[4, 4, True, True, True, False, False, False, False, 'DE']
+    title: Scanned WIFI Hotspots
+    description: List of available WIFI hotspots to connect to 
+  scas:
+    type: integer
+    example: 2
+  sch_satur:
+    type: object
+    example: control=0, ranges=[namespace(begin=namespace(hour=0, minute=0), end=namespace(hour=0, minute=0)), namespace(begin=namespace(hour=0, minute=0), end=namespace(hour=0, minute=0))]
+    title: Charging Schedule Saturday
+    description: The charging schedule for Saturdays
+  sch_sund:
+    type: object
+    example: namespace(control=0, ranges=[namespace(begin=namespace(hour=0, minute=0), end=namespace(hour=0, minute=0)), namespace(begin=namespace(hour=0, minute=0), end=namespace(hour=0, minute=0))]
+    title: Charging Schedule Sunday
+    description: The charging schedule for Sundays
+  sch_week:
+    type: object
+    example: control=0, ranges=[namespace(begin=namespace(hour=0, minute=0), end=namespace(hour=0, minute=0)), namespace(begin=namespace(hour=0, minute=0), end=namespace(hour=0, minute=0))]
+    title: Charging Schedule Weekday
+    description: The charging schedule for weekdays
+  sdca:
+    type: integer
+    example: 2
+  sh:
+    type: integer
+    example: 200
+  smca:
+    type: integer
+    example: 2
+  smd:
+    type: unknown
+    example: None
+  spl3:
+    type: integer
+    example: 4200
+  sse:
+    type: integer
+    example: <some_serialnr>
+  stao:
+    type: unknown
+    example: None
+  su:
+    type: boolean
+    example: False
+  sua:
+    type: boolean
+    example: False
+  sumd:
+    type: integer
+    example: 5000
+  swc:
+    type: boolean
+    example: False
+  tds:
+    type: integer
+    example: 1
+  tma:
+    type: array
+    example: [11, 16.75]
+    itemType: float
+  tof:
+    type: integer
+    example: 60
+  tou:
+    type: integer
+    example: 0
+  tpa:
+    type: integer
+    example: 0
+  tpck:
+    type: array
+    example: ['chargectrl', 'i2c', 'led', 'wifi', 'webserver', 'mdns', 'time', 'cloud', 'rfid', 'temperature', 'status', 'froniusinverter', 'button', 'delta_http', 'delta_cloud', 'ota_cloud', 'cmdhandler', 'loadbalancing', 'ocpp', 'remotereq', 'cloud_send']
+    itemType: string
+  tpcm:
+    type: array
+    example: [4, 0, 3, 1, 0, 0, 0, 0, 43, 2, 53, 0, 0, 0, 50, 0, 0, 0, 0, 0, 10]
+    itemType: integer
+  trx:
+    type: unknown
+    example: None
+  ts:
+    type: string
+    example: europe.pool.ntp.org
+  tse:
+    type: boolean
+    example: False
+  tsom:
+    type: integer
+    example: 0
+  tssi:
+    type: integer
+    example: 3600000
+  tssm:
+    type: integer
+    example: 0
+  tsss:
+    type: integer
+    example: 0
+  typ:
+    type: string
+    example: wattpilot
+  uaca:
+    type: integer
+    example: 2
+  upd:
+    type: boolean
+    example: False
+    note: This property is referenced in the wattpilot module, but does not seem to be available
+  upo:
+    type: boolean
+    example: False
+  ust:
+    type: integer
+    example: 0
+    alias: cableLock
+  utc:
+    type: string
+    example: 2022-03-06T10:59:38.181.250
+  var:
+    type: integer
+    example: 11
+  waap:
+    type: integer
+    example: 3
+  wae:
+    type: boolean
+    example: True
+  wak:
+    type: boolean
+    example: False
+  wan:
+    type: string
+    example: Wattpilot_<some_serialnr>
+  wapc:
+    type: integer
+    example: 1
+  wcb:
+    type: string
+    example: <some_mac>
+  wcch:
+    type: integer
+    example: 0
+  wccw:
+    type: integer
+    example: 2
+  wda:
+    type: boolean
+    example: False
+  wen:
+    type: boolean
+    example: True
+  wfb:
+    type: unknown
+    example: None
+  wh:
+    type: float
+    example: 2133.804
+    alias: energyCounterSinceStart
+  wifis:
+    type: array
+    itemType: object
+    example: ssid='<SOME_SSID>', key=True, useStaticIp=False, staticIp='0.0.0.0', staticSubnet='0.0.0.0', staticGateway='0.0.0.0', useStaticDns=False, staticDns0='0.0.0.0', staticDns1='0.0.0.0', staticDns2='0.0.0.0'
+    title: Configured WIFI Networks?
+  wpb:
+    type: array
+    itemType: string
+    example: '<SOME_BSSID>'
+  wsc:
+    type: integer
+    example: 0
+  wsm:
+    type: string
+    example: 
+  wsmr:
+    type: integer
+    example: -90
+  wsms:
+    type: integer
+    example: 3
+  wss:
+    type: unknown
+    example: 
+    alias: wifiSsid
+    note: This property is referenced in the wattpilot module, but does not seem to be available
+  wst:
+    type: integer
+    example: 3
+  zfo:
+    type: integer
+    example: 200

--- a/wattpilot.yaml
+++ b/wattpilot.yaml
@@ -41,6 +41,8 @@ messages:
 # - alias: A unique alias that can be used as a better descriptive name for a self-descriptive API
 # - min: Minimum value in case the type is 'integer' or 'float'
 # - max: Maximum value in case the type is 'integer' or 'float'
+# There seems to be a large overlap to the properties of the go-eCharger API as documented here:
+# - https://github.com/goecharger/go-eCharger-API-v1/blob/master/go-eCharger%20API%20v1%20EN.md
 properties:
   abm:
     type: string


### PR DESCRIPTION
This PR implements a simple interactive shell to explore all available Wattpilot properties and change their values.
There are some minor extensions to the wattpilot module to be able to handle all possible properties and to detect when all properties have successfully been initialized.

Here's more information (also available in README.md):

## Wattpilot Shell

The shell provides an easy way to explore the available properties and get or set their values.

```bash
# Install the wattpilot module, if not yet done so:
pip install .
```

Run the interactive shell

```bash
# Usage:
python3 shell.py <wattpilot_ip> <password>
> help
Wattpilot Shell Commands:
  dump: Dump all property values
  exit: Exit the shell
  get <name>: Get a property value
  info: Print most important infos
  list: List all known property keys
  set <name> <value>: Set a property value
  watch message <type>: Watch message of given message type
  watch property <name>: Watch value changes of given property name
  unwatch message <type>: Unwatch messages of given message type
  unwatch property <name>: Unwatch value changes of given property name
```

It's also possible to pass a single command to the shell to integrate it into scripts:

```bash
# Usage:
python3 shell.py <wattpilot_ip> <password> "<command> <args...>"

# Examples:
python3 shell.py <wattpilot_ip> <password> "get amp"
python3 shell.py <wattpilot_ip> <password> "set amp 6"
```
